### PR TITLE
Add set codec

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,4 +16,4 @@ jobs:
       - run: yarn jest
       - run: npm publish --access public
         env:
-          NPM_TOKEN: ${{secrets.NPM_TOKEN}}
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export {list} from "./list";
 export {map} from "./map";
+export {set} from "./set";

--- a/src/set.ts
+++ b/src/set.ts
@@ -1,0 +1,27 @@
+import * as t from "io-ts";
+import {Set} from "immutable";
+import {isLeft} from "fp-ts/lib/Either";
+
+/**
+ * A codec for the Set type from immutable.
+ * This codec decodes a javascript array into an immutable set, and it encodes the immutable set to a javascript array
+ * @param codec The codec for the set items.
+ * @since 0.1.0
+ */
+export function set<C extends t.Mixed>(codec: C) {
+    type Item = t.TypeOf<C>;
+    type ItemOutput = t.OutputOf<C>;
+
+  return new t.Type<Set<Item>, Array<ItemOutput>, unknown>(
+    `Set<${codec.name}>`,
+    (u: unknown): u is Set<Item> => Set.isSet(u) && u.every(uItem => codec.is(uItem)),
+    (u: unknown, context) => {
+        const decodedArray = t.array(codec).validate(u, context);
+        if(isLeft(decodedArray)) {
+            return t.failure(u, context, "Could not decode input to an array");
+        }
+        return t.success(Set(decodedArray.right));
+    },
+    (s) => s.map(codec.encode).toArray()
+  );
+}

--- a/test/set.test.ts
+++ b/test/set.test.ts
@@ -1,0 +1,76 @@
+import * as tImmutable from "../lib/index";
+import * as t from "io-ts";
+import {Set} from "immutable";
+import {isRight} from "fp-ts/lib/Either";
+
+describe("is", () => {
+
+    it("is returns true if u is a set with all items matching the given codec", () => {
+        const isSet = tImmutable.set(t.string).is(Set.of("a", "b", "c"));
+        expect(isSet).toBeTruthy();
+    });
+
+    it("is returns false if u is a set and only some items match the given codec", () => {
+        const isSet = tImmutable.set(t.string).is(Set.of<any>("a", 1, "b"));
+        expect(isSet).toBeFalsy();
+    });
+
+    it("is returns false if u is a set and none of the items match the given codec", () =>{
+        const isSet = tImmutable.set(t.string).is(Set.of(1,2,3));
+        expect(isSet).toBeFalsy();
+    });
+
+    it("is returns false if u is not a set", () => {
+        const isSet = tImmutable.set(t.string).is(["a", "b", "c"]);
+        expect(isSet).toBeFalsy();
+    });
+});
+
+describe("decode", () => {
+
+    it("decodes an empty array", () => {
+        const input: Array<string> = [];
+        const output = tImmutable.set(t.string).decode(input);
+        expect(isRight(output)).toBeTruthy();
+        // @ts-ignore
+        expect(output.right).toEqual(Set.of())
+
+    });
+
+    it("decodes a non empty array", () => {
+        const input = ["a", "b", "c"];
+        const output = tImmutable.set(t.string).decode(input);
+        expect(isRight(output)).toBeTruthy();
+        // @ts-ignore
+        expect(output.right).toEqual(Set.of("a", "b", "c"));
+    });
+
+    it("fails decoding an array with the wrong content", () => {
+        const input = ["a", "b", "c"];
+        const output = tImmutable.set(t.number).decode(input);
+        expect(isRight(output)).toBeFalsy();
+    });
+
+    it("fails decoding a object that is not an array", () => {
+        const input = "abc";
+        const output = tImmutable.set(t.string).decode(input);
+        expect(isRight(output)).toBeFalsy();
+    });
+
+});
+
+describe("encode", () => {
+
+    it("encodes an empty set", ()=> {
+        const input = Set();
+        const output = tImmutable.set(t.string).encode(input);
+        expect(output).toEqual([]);
+    });
+
+    it("encodes a non empty set", () => {
+        const input = Set.of("1", "2", "3");
+        const output = tImmutable.set(t.string).encode(input);
+        expect(output).toEqual(["1", "2", "3"]);
+    });
+
+});


### PR DESCRIPTION
Thanks for making this library! I added a codec for `Set` based on the existing codec for `List`. In the doc comment for `set`, I left `@since` as `0.1.0` so you can bump as intended next time you publish.